### PR TITLE
Several More Tweaks

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Box from "@mui/material/Box"
-import {Theme} from "@mui/material/styles"
-import {ThemeProvider} from "@mui/material/styles"
+import {Theme, ThemeProvider} from "@mui/material/styles"
 
 import Sidebar from "./Sidebar";
 import Part from "./Part";
@@ -27,7 +26,8 @@ class App extends React.Component<IProps , IState>{
   private parts: Map<string, Part[]> = new Map([
       ["Input", [
         new Part({type: PartType.INPUT, subtype: 0, label: "Clock"}),
-        new Part({type: PartType.INPUT, subtype: 1, label:"Switch"}),
+        new Part({type: PartType.INPUT, subtype: 1, label: "Switch"}),
+        new Part({type: PartType.INPUT, subtype: 2, label: "Ground"}),
       ]],
       ["Output", [
         new Part({type: PartType.OUTPUT, subtype: 0, label:"Bulb"}),

--- a/src/components/Component.tsx
+++ b/src/components/Component.tsx
@@ -72,6 +72,7 @@ class Component extends React.Component<GateProps, IState> {
                       onMouseMove={this.props.handlers.onGateMouseMove}
                       onContextMenu={this.props.handlers.onGateContextMenu}
                 />
+                {this.props.logicComponent.pins().map(p => p.renderLabel())}
                 {gate.extraRender()}
                 {pins}
             </g>

--- a/src/components/Connection.tsx
+++ b/src/components/Connection.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import LogicConnection from "../logic/LogicConnection";
-import LogicState from "../logic/LogicState";
 
 interface Point {
   x: number,
@@ -9,8 +8,6 @@ interface Point {
 
 interface IProps {
   connection: LogicConnection;
-  state: LogicState;
-  width: number;
   /** The first endpoint of this connection */
   i: Point;
   /** The second endpoint of this connection */
@@ -58,7 +55,7 @@ class Connection extends React.Component<IProps, IState> {
     let d = `${end1_1} ${end1_2} M ${ix} ${iy} C ${icx} ${icy} ${ocx} ${ocy} ${ox} ${oy} ${end2_1} ${end2_2}`;
 
     let fillClass;
-    let state = this.props.state;
+    let state = this.props.connection.source.state;
     if (state.x) {
       fillClass = "error"
     } else if (state.z) {
@@ -83,7 +80,7 @@ class Connection extends React.Component<IProps, IState> {
           <path className="connection-outer" d={d}/>
           <path fillRule="nonzero"
               className={`connection-inner ${fillClass}`} d={d}/>
-          { this.props.width > 1 &&
+          { this.props.connection.source.width > 1 &&
             <path fillRule="nonzero" className="connection-inner bus" d={d}/>}
         </g>
     );

--- a/src/components/Part.tsx
+++ b/src/components/Part.tsx
@@ -9,6 +9,7 @@ import Clock from "../logic/Clock";
 import Switch from "../logic/Switch";
 import paper from "paper";
 import Adder from "../logic/Adder";
+import Ground from "../logic/Ground";
 
 interface PartParams {
   type: PartType,
@@ -56,6 +57,8 @@ class Part {
         return new Clock({board: board, scope: scope, subtype: 0})
       case 1:
         return new Switch({subtype: 1, board: board, scope: scope})
+      case 2:
+        return new Ground({subtype: 2, board: board, scope: scope})
       default:
         throw new Error("Unsupported Part Type");
     }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import Part from "./Part";
 
 import PartsDrawer from "./PartsDrawer";
 import "../css/Sidebar.css"
+import Divider from "@mui/material/Divider";
 
 
 function a11yProps(index: number) {
@@ -98,7 +99,7 @@ class Sidebar extends React.Component<IProps, IState> {
         textOrientation: "mixed",
         transform: "rotate(180deg)"}}>{label}</Box>}
          value={label} {...a11yProps(index)}
-         sx={{minWidth: "48px"}}
+         sx={{minWidth: "48px", minHeight: "100px"}}
          onClick={this.handleTabClick.bind(this, label)}/>
     );
   }
@@ -115,8 +116,11 @@ class Sidebar extends React.Component<IProps, IState> {
               sx={{ borderRight: 1, borderColor: 'divider', flexShrink: 0, minWidth: '48px'}}
           >
             {this.renderTab("Project", 0)}
+            <Divider/>
             {this.renderTab("Parts", 1)}
+            <Divider/>
           </Tabs>
+          <Divider orientation="vertical" sx={{zIndex: 'drawer'}}/>
           <div style={{position: "absolute", left: "50px", width: "100%", height: "100%", overflow: "hidden", pointerEvents: "none"}}>
             {this.renderUnderlay()}
             {this.renderProjectView()}

--- a/src/logic/Adder.tsx
+++ b/src/logic/Adder.tsx
@@ -71,14 +71,16 @@ class Adder extends LogicComponent {
             pinType: PinType.OUTPUT,
             orientation: PinOrientation.UP,
             board: this.board,
-            width: this.width
+            width: this.width,
+            label: 'S',
         });
 
         let cout = new LogicPin({
             parent: this,
             pinType: PinType.OUTPUT,
             orientation: PinOrientation.LEFT,
-            board: this.board
+            board: this.board,
+            label: "C__out",
         });
 
         sum.updateGeometry(new this.scope.Point(24, 0));
@@ -93,7 +95,8 @@ class Adder extends LogicComponent {
             pinType: PinType.INPUT,
             orientation: PinOrientation.DOWN,
             board: this.board,
-            width: this.width
+            width: this.width,
+            label: 'A',
         });
         a.updateGeometry(new this.scope.Point(16, 32));
 
@@ -102,7 +105,8 @@ class Adder extends LogicComponent {
             pinType: PinType.INPUT,
             orientation: PinOrientation.DOWN,
             board: this.board,
-            width: this.width
+            width: this.width,
+            label: 'B',
         });
         b.updateGeometry(new this.scope.Point(32, 32));
 
@@ -115,26 +119,12 @@ class Adder extends LogicComponent {
             parent: this,
             pinType: PinType.INPUT,
             orientation: PinOrientation.RIGHT,
-            board: this.board
+            board: this.board,
+            label: "C__in",
         });
         cin.updateGeometry(new this.scope.Point(48, 16));
 
         return [a, b, cin];
-    }
-
-    extraRender(): React.ReactElement[] {
-        return [
-            <>
-                <text className="top" x={24} y={0}>S</text>
-                <text className="left" x={0} y={16}>C<tspan>out</tspan></text>
-                <text className="bottom" x={16} y={32}>A</text>
-                <text className="bottom" x={32} y={32}>B</text>
-                {this.subtype === 1 && <text className="right" x={48} y={16}>C<tspan>in</tspan></text>}
-            </>
-        ];
-    }
-
-    reset() {
     }
 }
 

--- a/src/logic/Adder.tsx
+++ b/src/logic/Adder.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import LogicComponent, {LogicComponentParams} from "./LogicComponent";
 import LogicPin, {PinOrientation, PinType} from "./LogicPin";
 import PartType from "../enums/PartType";

--- a/src/logic/Bulb.tsx
+++ b/src/logic/Bulb.tsx
@@ -18,16 +18,17 @@ class Bulb extends LogicComponent {
 
   operate(): void {
     this.on = this.inputPins[0].state.v === 1;
+    this.update();
   }
 
   /** Renders the glow of the bulb if the bulb is in the on state */
-  extraRender(): React.ReactElement[] {
+  extraRender(): React.ReactElement {
     // TODO: Render the glow on top of all other components.
     //   SVG renders elements in document order.
     let display = this.on ? "auto" : "none"
-    return [
-        <circle key={0} className={"bulb-glow"} cx={16} cy={16} r={32} display={display}/>
-    ];
+    return (
+        <circle className={"bulb-glow"} cx={16} cy={16} r={32} display={display}/>
+    );
   }
 
   setUpBody(): paper.Item {
@@ -46,11 +47,6 @@ class Bulb extends LogicComponent {
     pin.updateGeometry(new paper.Point(16, bottom));
     return [pin];
   }
-
-  /** No-op */
-  reset() {
-  }
-
 }
 
 export default Bulb;

--- a/src/logic/Clock.tsx
+++ b/src/logic/Clock.tsx
@@ -41,15 +41,16 @@ class Clock extends LogicComponent {
     return [pin];
   }
 
-  extraRender(): React.ReactElement[] {
-    return [
-      <path className="decoration" key={0} d={Clock.clockPath} fill="none"/>
-    ];
+  extraRender(): React.ReactElement {
+    return (
+      <path className="decoration" d={Clock.clockPath} fill="none"/>
+    );
   }
 
   reset() {
     let [output] = this.outputPins;
     output.setLogicState(new LogicState({v: 0}));
+    output.updateNext(true);
     this.operate();
   }
 }

--- a/src/logic/Ground.tsx
+++ b/src/logic/Ground.tsx
@@ -1,3 +1,5 @@
+import React from "react"
+
 import LogicComponent, {LogicComponentParams} from "./LogicComponent";
 import LogicPin, {PinOrientation, PinType} from "./LogicPin";
 import PartType from "../enums/PartType";
@@ -33,15 +35,15 @@ class Ground extends LogicComponent {
         return [pin];
     }
 
-    extraRender(): React.ReactElement[] {
-        return [
+    extraRender(): React.ReactElement {
+        return (
              <path d="
-                M16,6.5 v12
-                M10,19.5 h12
+                M16,6.5 v13
+                M9.5,19.5 h13
                 M12,22.5 h8
-                M14,25.5 h4
+                M14.5,25.5 h3
             "/>
-        ];
+        );
     }
 }
 

--- a/src/logic/Ground.tsx
+++ b/src/logic/Ground.tsx
@@ -1,0 +1,48 @@
+import LogicComponent, {LogicComponentParams} from "./LogicComponent";
+import LogicPin, {PinOrientation, PinType} from "./LogicPin";
+import PartType from "../enums/PartType";
+import LogicState from "./LogicState";
+
+interface IParams extends Omit<LogicComponentParams, "flags" | "type" | "width"> {}
+
+class Ground extends LogicComponent {
+    constructor(params: IParams ) {
+        super({...params, flags: 0, type: PartType.INPUT});
+    }
+
+    operate(): void {
+        this.outputPins[0].setLogicState(new LogicState({}))
+    }
+
+    reset(): void {
+    }
+
+    setUpBody(fieldWidth: number): paper.Item {
+        let {Path, Point, Size} = this.scope;
+        return new Path.Rectangle(new Point(0, 0), new Size(32, 32));
+    }
+
+    setUpOutputPins(): LogicPin[] {
+        let pin = new LogicPin({
+            parent: this,
+            pinType: PinType.OUTPUT,
+            orientation: PinOrientation.RIGHT,
+            board: this.board,
+        })
+        pin.updateGeometry(new this.scope.Point(32, 16))
+        return [pin];
+    }
+
+    extraRender(): React.ReactElement[] {
+        return [
+             <path d="
+                M16,6.5 v12
+                M10,19.5 h12
+                M12,22.5 h8
+                M14,25.5 h4
+            "/>
+        ];
+    }
+}
+
+export default Ground

--- a/src/logic/LogicBoard.tsx
+++ b/src/logic/LogicBoard.tsx
@@ -60,14 +60,10 @@ class LogicBoard {
   }
 
   stopSimulation() {
-    if (this.simulationTimerId !== -1) {
-      clearInterval(this.simulationTimerId);
-      this.simulationTimerId = -1;
-      this.simulation.clear();
-      this.simulationCurrentTime = 0;
-      this.components.forEach(c => c.reset());
-      this.components.forEach(c => c.operate());
-    }
+    this.pauseSimulation();
+    this.simulation.clear();
+    this.components.forEach(c => c.reset());
+    this.simulationCurrentTime = 0;
   }
 
   pauseSimulation() {
@@ -88,6 +84,10 @@ class LogicBoard {
       event.apply();
     }
     this.simulationCurrentTime = target;
+    // TODO(dpasillas): Remove this call once we've identified where the simulation state may be referenced, and
+    //                  appropriate channels have been created to send the data where it's needed.
+    //
+    // This call re-renders the entire app, which may be needlessly expensive.
     this.updateFunc();
   }
 

--- a/src/logic/LogicComponent.tsx
+++ b/src/logic/LogicComponent.tsx
@@ -249,8 +249,8 @@ abstract class LogicComponent {
    *
    * For example, this may be used to draw pin labels, light from activated bulbs, or the interactive part of a button.
    * */
-  extraRender(): React.ReactElement[] {
-    return [];
+  extraRender(): React.ReactElement {
+    return <></>;
   }
 
   /** Maps this logical component to a React Component */
@@ -291,7 +291,11 @@ abstract class LogicComponent {
   /** Performs a logical operation */
   abstract operate(): void
   /** Returns the component to its initial state at power up */
-  abstract reset(): void
+  reset() {
+    for (let pin of this.pins()) {
+      pin.reset();
+    }
+  }
 }
 
 export default LogicComponent;

--- a/src/logic/LogicConnection.tsx
+++ b/src/logic/LogicConnection.tsx
@@ -56,8 +56,6 @@ class LogicConnection {
     return (
         <Connection key={this.uuid}
                     connection={this}
-                    state={this.source.state}
-                    width={this.source.width}
                     i={ianchor}
                     o={oanchor}
                     ic={ic}

--- a/src/logic/LogicGate.tsx
+++ b/src/logic/LogicGate.tsx
@@ -201,6 +201,9 @@ class LogicGate extends LogicComponent {
   }
 
   operate(): void {
+    if (!this.opFunc) {
+      return;
+    }
     let logicState = this.opFunc();
     this.postEvent(logicState, this.outputPins[0])
   }
@@ -257,11 +260,6 @@ class LogicGate extends LogicComponent {
     pin.updateGeometry(new paper.Point(32, 16))
 
     return [pin];
-  }
-
-  reset() {
-    let [output] = this.outputPins;
-    output.setLogicState(new LogicState({x: this.bitMask()}))
   }
 }
 

--- a/src/logic/Switch.tsx
+++ b/src/logic/Switch.tsx
@@ -12,8 +12,8 @@ class Switch extends LogicComponent {
         super({...params, type: PartType.INPUT, flags: 0});
     }
 
-    operate(): void {
-    }
+    /** Intentionally no-op */
+    operate(): void {}
 
     setUpBody(fieldWidth: number): paper.Item {
         let {Path, Point, Size} = this.scope;
@@ -34,7 +34,7 @@ class Switch extends LogicComponent {
         return [pin];
     }
 
-    extraRender(): React.ReactElement[] {
+    extraRender(): React.ReactElement {
         let [pin] = this.outputPins
         let extras = []
         for (let i = 0; i < this.width; i++) {
@@ -48,8 +48,9 @@ class Switch extends LogicComponent {
             let x = 16 + 32 * (this.width - i - 1);
             let y = 16;
 
+            // TODO: Pass mouse events over the button to the parent element
             extras.push(
-                <circle key={i}
+                <circle key={2*i}
                         className={classnames.join(' ')}
                         cx={x}
                         cy={y}
@@ -57,12 +58,12 @@ class Switch extends LogicComponent {
                         onClick={this.handleClick.bind(this, i)}/>
             )
             extras.push(
-                <text className="center" color="red" x={x} y={y}>
+                <text key={2*i + 1} className="center" x={x} y={y}>
                     {stateString}
                 </text>
             )
         }
-        return extras
+        return <>{extras}</>
 
     }
 
@@ -75,8 +76,13 @@ class Switch extends LogicComponent {
         this.update();
     }
 
-    /** Intentionally no-op */
-    reset(): void { }
+    /** Reset but keep prior state */
+    reset(): void {
+        let [output] = this.outputPins;
+        let s = output.state;
+        super.reset();
+        output.setLogicState(s);
+    }
 }
 
 export default Switch;


### PR DESCRIPTION
# What does this code do?
Updated reset logic
Added dividers to left panel
Added automatic pin labeling and updated Adder to use it
Removes props from Connection.tsx to allow self-rerendering
Refactored extraRender on LogicComponent.tsx to return a single element
Updated existing extraRender calls to return a fragment instead of an array
Updated simulation stop logic

# What testing did you do?
Ran a few simulations to verify expected reset and stop behavior
Ensured that gates were properly set from the beginning before any simulation occurred
Verified that pin labels for adder remained after switching to automatic pin labeling
Verified that exiting extraRenders calls appeared as before


# Meta
Closes #43  
