### PR TITLE
Updated drag-and-drop connections

### DIFF
--- a/src/components/Pin.tsx
+++ b/src/components/Pin.tsx
@@ -62,7 +62,8 @@ class Pin extends React.Component<PinProps, IState> {
                     onMouseUp={this.props.handlers?.onPinMouseUp}
                     onContextMenu={this.props.handlers?.onPinContextMenu}
                 >
-                    <circle className="anchor" cx={anchor.x} cy={anchor.y} r={5} />
+                    {/* The drawn circle is the drop target: same radius the drop is tested against. */}
+                    <circle className="anchor" cx={anchor.x} cy={anchor.y} r={LogicPin.ANCHOR_RADIUS} />
                     <path {...pathAttributes} />
                     {this.props.pin.width > 1 && <path className="wide" {...pathAttributes} />}
                 </g>

--- a/src/logic/LogicComponent.tsx
+++ b/src/logic/LogicComponent.tsx
@@ -9,6 +9,7 @@ import {Component, GateEventHandlers, GateProps} from "../components/Component";
 import {LogicState} from "./LogicState";
 import {LogicBoard} from "./LogicBoard";
 import {ComponentProperty} from "./ComponentProperty";
+import {bitMask} from "../util/bits";
 
 
 /**
@@ -194,8 +195,7 @@ abstract class LogicComponent {
    * If no width is specified, defaults to this component's width.
    * */
   bitMask(numBits?: number): number {
-    numBits = numBits ?? this.width;
-    return (1 << numBits) - 1;
+    return bitMask(numBits ?? this.width);
   }
 
   /** Returns all pins associated with this component */

--- a/src/logic/LogicPin.tsx
+++ b/src/logic/LogicPin.tsx
@@ -7,6 +7,7 @@ import {LogicState} from "./LogicState";
 import {LogicConnection} from "./LogicConnection";
 import * as paper from "paper";
 import {LogicBoard} from "./LogicBoard";
+import {bitMask} from "../util/bits";
 
 export enum PinOrientation {
   UNKNOWN,
@@ -45,6 +46,16 @@ interface IParams {
  * A pin is any input or output to/from a LogicComponent
  * */
 class LogicPin {
+  /**
+   * Radius of the circle a connection attaches to.
+   *
+   * This is both what gets drawn and what a drop is tested against, so the target a user aims at is
+   * the target they actually hit. Pins on the denser components sit closer together than twice this,
+   * so the circles can still overlap and the caller has to pick the nearest rather than the first
+   * one in range.
+   */
+  static readonly ANCHOR_RADIUS = 5;
+
   private parent: LogicComponent;
   private connectionAnchor?: paper.Point;
   readonly uuid: string;
@@ -309,9 +320,14 @@ class LogicPin {
     return isSelected;
   }
 
-  isOver(point: paper.Point): boolean {
+  /** How far the given board point is from where a connection would attach. */
+  distanceTo(point: paper.Point): number {
     const [anchor,] = this.anchor
-    return this.transform(anchor).getDistance(point) < 15
+    return this.transform(anchor).getDistance(point)
+  }
+
+  isOver(point: paper.Point): boolean {
+    return this.distanceTo(point) < LogicPin.ANCHOR_RADIUS
   }
 
   /**
@@ -320,8 +336,7 @@ class LogicPin {
    * If no width is specified, defaults to this component's width.
    * */
   bitMask(numBits?: number): number {
-    numBits = numBits ?? this.width;
-    return (1 << numBits) - 1;
+    return bitMask(numBits ?? this.width);
   }
 
   /** Returns a pin to its default state */

--- a/src/logic/LogicState.ts
+++ b/src/logic/LogicState.ts
@@ -1,3 +1,4 @@
+import {bitMask} from "../util/bits";
 
 interface IParams {
   v?: number; // non-error value
@@ -54,8 +55,7 @@ class LogicState {
    * state.negate(5)
    * */
   negated(numBits: number) {
-    // (2^n) - 1 will result in a mask with the lower n bits set.
-    const mask = (1 << numBits) - 1
+    const mask = bitMask(numBits)
 
     // Bits with corresponding errors should be masked out
     const v = ~this.v & ~this.x & ~this.z & mask;

--- a/src/util/MouseManager.ts
+++ b/src/util/MouseManager.ts
@@ -249,14 +249,30 @@ class MouseManager {
 
       const sourcePin = this.targetComponent as unknown as LogicPin;
 
-      // Find if we dropped on a pin
+      // The pin nearest the drop, out of those it could legally connect to.
+      //
+      // Both halves of that matter. The snap radius is wider than the gap between pins on a display
+      // or a splitter, so several pins are typically in range and the nearest is the one aimed at;
+      // taking whichever came first put the connection on a neighbour. And filtering by what can
+      // actually connect first means an incompatible pin lying nearer — a single-bit channel beside
+      // a bus, say — no longer swallows the drop and leaves nothing connected.
+      let target: LogicPin | undefined;
+      let targetDistance = Infinity;
+
       for (const pin of board.pins.values()) {
-        if (pin !== sourcePin && pin.isOver(point)) {
-          if (sourcePin.canConnect(pin)) {
-            this.makeConnection(board, sourcePin, pin);
-          }
-          break;
+        if (pin === sourcePin || !sourcePin.canConnect(pin) || !pin.isOver(point)) {
+          continue;
         }
+
+        const distance = pin.distanceTo(point);
+        if (distance < targetDistance) {
+          targetDistance = distance;
+          target = pin;
+        }
+      }
+
+      if (target) {
+        this.makeConnection(board, sourcePin, target);
       }
     }
 

--- a/src/util/bits.test.ts
+++ b/src/util/bits.test.ts
@@ -1,0 +1,59 @@
+import {bitMask} from './bits';
+import {LogicState} from '../logic/LogicState';
+
+/**
+ * The mask the given width should produce, computed without 32-bit shift semantics and then read
+ * the way a bitwise operator would read it.
+ */
+function expected(numBits: number): number {
+  return Number(((1n << BigInt(numBits)) - 1n) & 0xFFFFFFFFn) | 0;
+}
+
+describe('bitMask', () => {
+  test.each([0, 1, 2, 8, 16, 30, 31, 32])('is correct at a width of %i', numBits => {
+    expect(bitMask(numBits)).toBe(expected(numBits));
+  });
+
+  test('reaches a full-width mask, which shifting cannot', () => {
+    // `~0 << 32` is `~0 << 0`, so the shifting form would come back as zero here.
+    expect(bitMask(32)).toBe(~0);
+  });
+
+  test('covers the top bit without overflowing into an invalid int32', () => {
+    // `(1 << 31) - 1` produced -2147483649, which is not a representable int32 at all.
+    expect(bitMask(31)).toBe(0x7FFFFFFF);
+  });
+
+  test('masks the bits it claims to', () => {
+    expect((0xDEADBEEF & bitMask(8)) >>> 0).toBe(0xEF);
+    expect((0xDEADBEEF & bitMask(16)) >>> 0).toBe(0xBEEF);
+    expect((0xDEADBEEF & bitMask(32)) >>> 0).toBe(0xDEADBEEF);
+  });
+
+  test('is in the representation every bitwise operator produces', () => {
+    // Masking with a full-width mask has to be an identity. It would not be if the mask were
+    // carried in a different representation from the value it is applied to.
+    for (const value of [0, 1, -1, 0x7FFFFFFF, ~0 << 31]) {
+      expect(value & bitMask(32)).toBe(value);
+    }
+  });
+});
+
+describe('states holding the same bits', () => {
+  test('compare equal however the bits were produced', () => {
+    // States are compared field by field with ===, which is not a bitwise operator and so does not
+    // reconcile representations itself. Every producer ends in a bitwise operation, which is what
+    // keeps them consistent — a mask carried as unsigned would break that on its own.
+    const fromMask = new LogicState({x: bitMask(32)});
+    const fromOperators = new LogicState({x: ~0});
+    const fromComplement = new LogicState({x: ~(0 & 0)});
+
+    expect(fromMask.eq(fromOperators)).toBe(true);
+    expect(fromMask.eq(fromComplement)).toBe(true);
+    expect(fromMask.ne(fromOperators)).toBe(false);
+  });
+
+  test('a full-width state differs from a partial one', () => {
+    expect(new LogicState({v: bitMask(32)}).eq(new LogicState({v: bitMask(31)}))).toBe(false);
+  });
+});

--- a/src/util/bits.ts
+++ b/src/util/bits.ts
@@ -1,0 +1,17 @@
+/**
+ * A mask with the low `numBits` bits set.
+ *
+ * Shift counts in JavaScript are taken modulo 32, so a full-width mask cannot be reached by
+ * shifting: `~0 << 32` is `~0 << 0`. The full-width case is therefore written out, as the same
+ * all-ones value the shifting form builds towards.
+ *
+ * The result is a signed int32, which is what every bitwise operator produces and therefore the
+ * representation the rest of the simulation already uses. At a full 32 bits that reads as -1; the
+ * bits are all ones either way, and staying in one representation is what lets two states holding
+ * the same pattern compare equal.
+ */
+function bitMask(numBits: number): number {
+  return numBits >= 32 ? ~0 : ~(~0 << numBits);
+}
+
+export {bitMask};

--- a/src/util/connectionDrop.test.ts
+++ b/src/util/connectionDrop.test.ts
@@ -1,0 +1,129 @@
+import {MouseManager} from './MouseManager';
+import {LogicBoard} from '../logic/LogicBoard';
+import {LogicComponent} from '../logic/LogicComponent';
+import {LogicPin} from '../logic/LogicPin';
+import {LogicGate} from '../logic/LogicGate';
+import {SegmentDisplay} from '../logic/SegmentDisplay';
+import {Splitter} from '../logic/Splitter';
+import {GateType} from '../enums/GateType';
+import {MouseEventMapping} from './MouseEventMapping';
+
+/** The board-space point at which a connection to this pin attaches. */
+function anchorOf(pin: LogicPin) {
+  return pin.transform(pin.anchor[0]);
+}
+
+/** Registers a component's pins with the board, as dropping one onto the board does. */
+function place(board: LogicBoard, component: LogicComponent) {
+  component.pins().forEach(pin => {
+    pin.board = board;
+    board.addPin(pin);
+  });
+}
+
+/**
+ * A single-bit driver, parked well clear of everything else.
+ *
+ * Its own pins are on the board like any other component's, so keeping it at a distance stops it
+ * from being a candidate for its own drop.
+ */
+function driver(board: LogicBoard): LogicPin {
+  const gate = new LogicGate({scope: board.scope, subtype: GateType.AND});
+  gate.translate(new board.scope.Point(500, 500));
+  place(board, gate);
+
+  return gate.outputPins[0];
+}
+
+/** Drags a connection from a pin and releases it at a point in board coordinates. */
+function dropAt(board: LogicBoard, source: LogicPin, to: {x: number, y: number}) {
+  const manager = new MouseManager();
+  manager.getViewCoordinates = (): MouseEventMapping =>
+    ({x: to.x, y: to.y, rx: 0, ry: 0, dx: 0, dy: 0});
+
+  const event = {
+    button: 0, clientX: 0, clientY: 0, altKey: false,
+    preventDefault: () => {}, stopPropagation: () => {}, getModifierState: () => false,
+  } as unknown as MouseEvent;
+
+  manager.handlePinMouseDown(board, source, event);
+  manager.handleMouseUp(board, event);
+}
+
+describe('dropping a connection', () => {
+  test('lands on the nearest pin, not the first one in range', () => {
+    // A 7-segment display spaces its pins 8 apart, closer than two anchor radii, so the circles
+    // overlap and a drop in that overlap is in range of both. Taking the first match resolved it by
+    // creation order, which handed the connection to whichever pin was made earlier.
+    const board = new LogicBoard();
+    const display = new SegmentDisplay({scope: board.scope, subtype: 1});
+    place(board, display);
+    const source = driver(board);
+
+    const [nearer, farther] = [display.inputPins[4], display.inputPins[3]];
+    const from = anchorOf(farther);
+    const to = anchorOf(nearer);
+    // Just past halfway, so the nearer pin is the one scanned second.
+    const drop = new board.scope.Point(from.x + (to.x - from.x) * 0.56,
+                                       from.y + (to.y - from.y) * 0.56);
+
+    // The premise: both are in range, and the farther one is checked first.
+    expect(farther.distanceTo(drop)).toBeLessThan(LogicPin.ANCHOR_RADIUS);
+    expect(nearer.distanceTo(drop)).toBeLessThan(farther.distanceTo(drop));
+    expect([...board.pins.values()].indexOf(farther))
+      .toBeLessThan([...board.pins.values()].indexOf(nearer));
+
+    dropAt(board, source, drop);
+
+    expect(display.inputPins.findIndex(p => source.isConnectedTo(p))).toBe(4);
+  });
+
+  test('is not swallowed by a nearer pin it cannot connect to', () => {
+    // The splitter is registered first and its bus pin lands a unit away from the display pin being
+    // aimed at, but it is two bits wide and cannot take a single-bit connection. The old scan
+    // stopped at the first pin in range whether or not it could be connected, so the drop was lost.
+    const board = new LogicBoard();
+    const splitter = new Splitter({scope: board.scope, subtype: 0, width: 2});
+    place(board, splitter);
+    const display = new SegmentDisplay({scope: board.scope, subtype: 1});
+    place(board, display);
+    const source = driver(board);
+
+    const aimedAt = display.inputPins[1];
+    const busPin = splitter.inputPins[0];
+    // The premise: the incompatible pin really is nearer, and really is checked first.
+    expect(busPin.distanceTo(anchorOf(aimedAt))).toBeLessThan(LogicPin.ANCHOR_RADIUS);
+    expect([...board.pins.values()].indexOf(busPin))
+      .toBeLessThan([...board.pins.values()].indexOf(aimedAt));
+
+    dropAt(board, source, anchorOf(aimedAt));
+
+    expect(source.isConnectedTo(aimedAt)).toBe(true);
+  });
+
+  test('accepts a drop exactly as far out as the circle it draws', () => {
+    // The catch area and the drawn circle are the same affordance. While the hit test was three
+    // times the radius of the circle, a drop could register on a pin the user never touched.
+    const board = new LogicBoard();
+    const display = new SegmentDisplay({scope: board.scope, subtype: 1});
+    place(board, display);
+    const target = display.inputPins[0];
+    const at = anchorOf(target);
+
+    const inset = (offset: number) => new board.scope.Point(at.x, at.y - offset);
+
+    expect(target.isOver(inset(LogicPin.ANCHOR_RADIUS - 0.5))).toBe(true);
+    expect(target.isOver(inset(LogicPin.ANCHOR_RADIUS + 0.5))).toBe(false);
+  });
+
+  test('connects nothing when the drop is not near any pin', () => {
+    const board = new LogicBoard();
+    const display = new SegmentDisplay({scope: board.scope, subtype: 1});
+    place(board, display);
+    const source = driver(board);
+
+    dropAt(board, source, {x: 5000, y: 5000});
+
+    expect(display.inputPins.some(p => source.isConnectedTo(p))).toBe(false);
+  });
+});


### PR DESCRIPTION
Made pin drop radius match pin anchor size.
On conflict, choose closest, rather than first.
Updated bit masking logic for consistency and to handle 32-bit masks