### PR TITLE
Delete action fixes and mouse scaling on load

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -101,7 +101,18 @@ class Board extends React.Component<IProps, IState> {
         }
 
         const { width, height } = entries[0].contentRect;
+        this.fitToViewPort(width, height);
+    }
 
+    /**
+     * Brings the region the board is showing into line with the editor showing it.
+     *
+     * The board holds which part of itself is on screen, while the editor holds how far it is
+     * zoomed, and neither is any use without the other: a region that does not match the shape of
+     * the element drawing it is both drawn at the wrong scale and pointed at in the wrong place,
+     * since a click is mapped through the region as though it filled the element exactly.
+     */
+    fitToViewPort(width: number, height: number) {
         const board = this.props.board;
         this.setState((state) => {
             board.viewBox = {
@@ -134,6 +145,30 @@ class Board extends React.Component<IProps, IState> {
         this.resizeObserver = new ResizeObserver(this.onResize.bind(this));
         this.resizeObserver.observe(board)
         this.mouseManager.getViewCoordinates = this.getViewCoordinates.bind(this);
+    }
+
+    /**
+     * Takes over a board handed to this editor in place of the one it was showing.
+     *
+     * A board keeps its identity across being saved and read back, so opening the project that is
+     * already open hands the editor a new board object under the same key and React keeps the
+     * editor it built for the old one. Nothing else would then tell the arriving board how large
+     * the editor is or how far it is zoomed, and it would be drawn and clicked through the size it
+     * was constructed with.
+     */
+    componentDidUpdate(previous: Readonly<IProps>) {
+        if (previous.board === this.props.board) {
+            return;
+        }
+
+        this.mouseManager.reset(previous.board);
+        previous.board.update = () => {};
+        this.props.board.update = () => this.setState({});
+
+        const rect = this.ref.current?.getBoundingClientRect();
+        if (rect) {
+            this.fitToViewPort(rect.width, rect.height);
+        }
     }
 
     /**

--- a/src/components/boardSwap.test.tsx
+++ b/src/components/boardSwap.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import {render} from '@testing-library/react';
+
+import {Board} from './Board';
+import {LogicBoard} from '../logic/LogicBoard';
+
+const {ResizeObserver} = window;
+
+/** The size the editor is pretending to be, which jsdom will not work out on its own. */
+const EDITOR = {width: 400, height: 300};
+
+beforeEach(() => {
+  // @ts-ignore
+  delete window.ResizeObserver;
+  window.ResizeObserver = vi.fn().mockImplementation(function () {
+    return {observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn()};
+  });
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    ...EDITOR, left: 0, top: 0, right: EDITOR.width, bottom: EDITOR.height, x: 0, y: 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+});
+
+afterEach(() => {
+  window.ResizeObserver = ResizeObserver;
+  vi.restoreAllMocks();
+});
+
+/** A board zoomed out, as one the user has scrolled away from would be. */
+function zoomed(): LogicBoard {
+  const board = new LogicBoard();
+  board.viewBox = {left: 0, top: 0, width: 800, height: 600};
+
+  return board;
+}
+
+describe('handing the editor a different board', () => {
+  test('fits the arriving board to the editor showing it', () => {
+    // A board keeps its identity across a save, so reopening the project that is already open
+    // swaps the object without rebuilding the editor. Left alone the new board keeps the size it
+    // was constructed with, and is drawn and clicked through a region that does not match.
+    const first = zoomed();
+    const second = zoomed();
+    const {rerender} = render(<Board board={first}/>);
+
+    rerender(<Board board={second}/>);
+
+    expect(second.viewBox.width).toBeCloseTo(EDITOR.width);
+    expect(second.viewBox.height).toBeCloseTo(EDITOR.height);
+  });
+
+  test('keeps where the board was scrolled to', () => {
+    const first = zoomed();
+    const second = zoomed();
+    second.viewBox = {left: 120, top: 40, width: 800, height: 600};
+    const {rerender} = render(<Board board={first}/>);
+
+    rerender(<Board board={second}/>);
+
+    expect(second.viewBox.left).toBe(120);
+    expect(second.viewBox.top).toBe(40);
+  });
+
+  test('starts redrawing the arriving board', () => {
+    const first = zoomed();
+    const second = zoomed();
+    const {rerender} = render(<Board board={first}/>);
+    const before = second.update;
+
+    rerender(<Board board={second}/>);
+
+    expect(second.update).not.toBe(before);
+  });
+
+  test('stops redrawing the one it let go of', () => {
+    const first = zoomed();
+    const second = zoomed();
+    const {rerender} = render(<Board board={first}/>);
+    const wired = first.update;
+
+    rerender(<Board board={second}/>);
+
+    expect(first.update).not.toBe(wired);
+  });
+
+  test('leaves the board alone when it is handed the same one again', () => {
+    const board = zoomed();
+    const {rerender} = render(<Board board={board}/>);
+    board.viewBox = {left: 0, top: 0, width: 123, height: 456};
+
+    rerender(<Board board={board}/>);
+
+    expect(board.viewBox.width).toBe(123);
+  });
+});

--- a/src/logic/LogicConnection.tsx
+++ b/src/logic/LogicConnection.tsx
@@ -39,6 +39,11 @@ class LogicConnection {
     this.source.connections.delete(this.sink.uuid);
     this.sink.connections.delete(this.source.uuid);
     this.board?.removeConnection(this.uuid);
+
+    // Nothing drives the far end any more, so it falls back to high impedance and its component
+    // works out what that means. Left alone it keeps the last value it was handed and goes on
+    // behaving as though the wire were still there.
+    this.sink.reset();
   }
 
   render() {

--- a/src/logic/LogicPin.tsx
+++ b/src/logic/LogicPin.tsx
@@ -132,10 +132,19 @@ class LogicPin {
     }
   }
 
-  /** Removes all connections associated with this pin */
+  /**
+   * Removes every wire attached to this pin.
+   *
+   * A pin joined to itself is left where it is. That is not a wire to anything the user drew, it is
+   * a component's own arrangement — a clock drives itself through one, and taking it away stops the
+   * clock for good.
+   */
   disconnect() {
-    this.connections.forEach((c) => c.remove());
-    this.connections.clear();
+    for (const connection of [...this.connections.values()]) {
+      if (connection.source !== connection.sink) {
+        connection.remove();
+      }
+    }
   }
 
   /** Indicates whether this pin may be connected to another */

--- a/src/logic/disconnecting.test.ts
+++ b/src/logic/disconnecting.test.ts
@@ -1,0 +1,136 @@
+import {LogicBoard} from './LogicBoard';
+import {LogicComponent} from './LogicComponent';
+import {LogicState} from './LogicState';
+import {Switch} from './Switch';
+import {makeComponent} from './componentFactory';
+import {GateType} from '../enums/GateType';
+import {PartType} from '../enums/PartType';
+
+function place(board: LogicBoard, type: PartType, subtype: number, x = 0): LogicComponent {
+  const component = makeComponent({type, subtype, scope: board.scope, board});
+  component.geometry.position = new board.scope.Point(x, 0);
+  board.addComponent(component);
+
+  return component;
+}
+
+function wire(board: LogicBoard, source: LogicComponent, sink: LogicComponent, input = 0) {
+  board.addConnection(sink.inputPins[input].connectTo(source.outputPins[0])!);
+}
+
+/** How many times the clock's output changes while the board runs. */
+function ticks(board: LogicBoard, clock: LogicComponent, steps = 80): number {
+  let changes = 0;
+  let last = clock.outputPins[0].state.v;
+
+  for (let i = 0; i < steps; i++) {
+    board.advanceSimulation();
+    const now = clock.outputPins[0].state.v;
+    if (now !== last) {
+      changes++;
+    }
+    last = now;
+  }
+
+  return changes;
+}
+
+describe('a clock whose wire is taken away', () => {
+  test('goes on ticking', () => {
+    // The clock keeps itself going through a connection from its output back to itself. Taking
+    // every connection off the pin took that one too, and the clock never ticked again.
+    const board = new LogicBoard();
+    const clock = place(board, PartType.INPUT, 0);
+    const gate = place(board, PartType.GATE, GateType.AND, 80);
+    wire(board, clock, gate);
+    board.stopSimulation();
+    expect(ticks(board, clock)).toBeGreaterThan(3);
+
+    clock.outputPins[0].disconnect();
+
+    expect(ticks(board, clock)).toBeGreaterThan(3);
+  });
+
+  test('goes on ticking when the wire is taken from the other end', () => {
+    const board = new LogicBoard();
+    const clock = place(board, PartType.INPUT, 0);
+    const gate = place(board, PartType.GATE, GateType.AND, 80);
+    wire(board, clock, gate);
+    board.stopSimulation();
+
+    gate.inputPins[0].disconnect();
+
+    expect(ticks(board, clock)).toBeGreaterThan(3);
+  });
+
+  test('goes on ticking after the Delete key reaches its pin', () => {
+    const board = new LogicBoard();
+    const clock = place(board, PartType.INPUT, 0);
+    const gate = place(board, PartType.GATE, GateType.AND, 80);
+    wire(board, clock, gate);
+    board.stopSimulation();
+    board.selectedPins.add(clock.outputPins[0]);
+
+    board.deleteSelection();
+
+    expect(board.connections.size).toBe(0);
+    expect(ticks(board, clock)).toBeGreaterThan(3);
+  });
+});
+
+describe('the pin a wire was feeding', () => {
+  test('stops being driven, rather than keeping the last value it was given', () => {
+    const board = new LogicBoard();
+    const toggles = place(board, PartType.INPUT, 1) as Switch;
+    const gate = place(board, PartType.GATE, GateType.AND, 80);
+    wire(board, toggles, gate);
+    toggles.outputPins[0].setLogicState(new LogicState({v: 1}));
+    expect(gate.inputPins[0].state.v).toBe(1);
+
+    gate.inputPins[0].disconnect();
+
+    expect(gate.inputPins[0].state.v).toBe(0);
+    expect(gate.inputPins[0].state.z).toBe(1);
+  });
+
+  test('is told, so that its component works out what losing the wire means', () => {
+    const board = new LogicBoard();
+    const toggles = place(board, PartType.INPUT, 1) as Switch;
+    const gate = place(board, PartType.GATE, GateType.AND, 80);
+    wire(board, toggles, gate);
+
+    let operated = 0;
+    const operate = gate.operate.bind(gate);
+    gate.operate = () => {operated++; operate()};
+
+    gate.inputPins[0].disconnect();
+
+    expect(operated).toBeGreaterThan(0);
+  });
+
+  test('stops being driven when the component driving it is removed', () => {
+    const board = new LogicBoard();
+    const toggles = place(board, PartType.INPUT, 1) as Switch;
+    const gate = place(board, PartType.GATE, GateType.AND, 80);
+    wire(board, toggles, gate);
+    toggles.outputPins[0].setLogicState(new LogicState({v: 1}));
+
+    toggles.remove();
+
+    expect(gate.inputPins[0].state.v).toBe(0);
+    expect(gate.inputPins[0].state.z).toBe(1);
+  });
+
+  test('stops being driven when the wire goes because the driver changed width', () => {
+    const board = new LogicBoard();
+    const toggles = place(board, PartType.INPUT, 1) as Switch;
+    const gate = place(board, PartType.GATE, GateType.AND, 80);
+    wire(board, toggles, gate);
+    toggles.outputPins[0].setLogicState(new LogicState({v: 1}));
+
+    toggles.width = 4;
+
+    expect(board.connections.size).toBe(0);
+    expect(gate.inputPins[0].state.z).toBe(1);
+  });
+});


### PR DESCRIPTION
Fix a board handed to a running editor, and two ways a wire outlived

Three faults, all in what happens when something is taken away.

A board keeps its identity across being saved and read back, so opening the project that is already open hands the editor a new board object under the same key and React keeps the editor it built for the old one. Nothing then told the arriving board how large the editor was or how far it was zoomed, so it kept the size it was constructed with: drawn at the wrong scale, and pointed at in the wrong place, since a click is mapped through the region as though it filled the element exactly. The editor now fits an arriving board to itself, and moves its redraw callback over with it.

Disconnecting a pin took every connection on it, including the one a clock runs from its output back to itself to keep ticking. That one is not a wire the user drew, and is now left where it is.

Removing a wire left the pin it fed holding the last value it was given, so the component behind it went on computing as though the wire were still there. The far end now falls back to high impedance and its component is told, which is what it would have had if the wire had never been drawn.