### PR TITLE
Pin connection UI and bug fixes

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,6 +5,8 @@ import {Theme, ThemeProvider} from "@mui/material/styles"
 
 import {Sidebar} from "./Sidebar";
 import {Properties} from "./Properties";
+import {NET_NAME_FIELD} from "./PinProperties";
+import {connectPins} from "../logic/nets";
 import {PARTS} from "./partsCatalogue";
 import {EditorTabs} from "./EditorTabs";
 import {MenuBar} from "./MenuBar";
@@ -67,6 +69,7 @@ function isTyping(target: EventTarget | null): boolean {
 class App extends React.Component<IProps , IState>{
   private project: Project = new Project();
   private readonly onKeyDown = this.handleKeyDown.bind(this);
+  private readonly onMouseDown = this.handleMouseDown.bind(this);
 
   /**
    * What was last copied, as data rather than as a hold on the components.
@@ -98,12 +101,14 @@ class App extends React.Component<IProps , IState>{
   componentDidMount() {
     this.watch(this.project.boards);
     window.addEventListener("keydown", this.onKeyDown);
+    window.addEventListener("mousedown", this.onMouseDown, true);
     this.reopenLast();
   }
 
   componentWillUnmount() {
     this.project.boards.forEach(board => {board.updateApp = () => {}});
     window.removeEventListener("keydown", this.onKeyDown);
+    window.removeEventListener("mousedown", this.onMouseDown, true);
   }
 
   /**
@@ -349,6 +354,76 @@ class App extends React.Component<IProps , IState>{
     this.setState({});
   }
 
+  /**
+   * Wires the selected pins together and offers to name what they now form.
+   *
+   * The wires are only half of it: a net is worth a name, and the name is what lets the same net be
+   * added to later without drawing to it. So the panel is brought up whether or not there was
+   * anything to wire — a set of inputs has no output to drive it, and putting them on a named net
+   * is exactly how that gets one.
+   */
+  private handleConnectPins() {
+    // A selection that could not share a net wires nothing, and the panel about to come up says so
+    // against the field itself — which is a better place for it than a notice that flies past.
+    if (connectPins(this.board, [...this.board.selectedPins]) > 0) {
+      this.board.update();
+    }
+
+    this.board.revealProperties();
+    this.setState({});
+    // The panel may only now be expanding, so the field is looked for after this render rather
+    // than during it. Its contents are taken as well as the caret: the name a pin already carries
+    // is what the user is most likely replacing, and selecting it means typing does that.
+    window.setTimeout(() => {
+      const field = document.getElementById(NET_NAME_FIELD);
+      if (field instanceof HTMLInputElement) {
+        field.focus();
+        field.select();
+      }
+    }, 0);
+  }
+
+  /**
+   * Puts down whatever the user had hold of: the caret in a panel field, and the selection.
+   *
+   * Left alone while a menu or dialog is up, where Escape already means "close this" and the
+   * selection is not what is being escaped from.
+   */
+  /**
+   * Lets go of a panel field when the user goes to work somewhere else.
+   *
+   * The board suppresses the browser's own handling of a press, so that a drag cannot move focus
+   * part-way through the gesture. That also means nothing takes focus off a field left behind, and
+   * a field that still has the caret goes on swallowing the keys the board answers to.
+   *
+   * Taken on the way down rather than on the way back up: the board stops a press from travelling
+   * any further once it has one, so waiting for it to bubble here would be waiting for good.
+   */
+  private handleMouseDown(e: MouseEvent) {
+    if (e.target instanceof Element && e.target.closest(".properties-content")) {
+      return;
+    }
+
+    const focused = document.activeElement;
+    if (focused instanceof HTMLElement && focused.closest(".properties-content")) {
+      focused.blur();
+    }
+  }
+
+  private handleEscape() {
+    if (document.querySelector(".MuiModal-root")) {
+      return;
+    }
+
+    const focused = document.activeElement;
+    if (focused instanceof HTMLElement && focused.closest(".properties-content")) {
+      focused.blur();
+    }
+
+    this.board.clearSelection();
+    this.setState({});
+  }
+
   private handleDuplicate() {
     duplicateSelection(this.board);
     this.setState({});
@@ -367,6 +442,14 @@ class App extends React.Component<IProps , IState>{
    * Ignored while a field has focus, where the same keys belong to the text being edited.
    */
   private handleKeyDown(e: KeyboardEvent) {
+    // Before the check below, unlike every other key here: stepping out of a field is most of what
+    // Escape is for, so it is the one key that has to reach this while a field has the caret.
+    if (e.key === "Escape") {
+      this.handleEscape();
+
+      return;
+    }
+
     if (isTyping(e.target)) {
       return;
     }
@@ -374,6 +457,15 @@ class App extends React.Component<IProps , IState>{
     if (e.key === "Delete") {
       e.preventDefault();
       this.handleDelete();
+
+      return;
+    }
+
+    // One pin has nothing to be wired to, but naming it is the other half of what this does, and
+    // that is worth reaching by the same key.
+    if (e.key === " " && this.board.selectedPins.size > 0) {
+      e.preventDefault();
+      this.handleConnectPins();
 
       return;
     }

--- a/src/components/PartsDrawer.tsx
+++ b/src/components/PartsDrawer.tsx
@@ -16,6 +16,13 @@ interface IProps {
   parts: Array<Part>,
   /** Held open by the panel while a filter is narrowing the list. */
   forceOpen?: boolean,
+  /**
+   * Whether an empty section still stands as tall open as a full one would.
+   *
+   * Set on a section that fills while the user is doing something else, so that its first part
+   * arriving does not move everything below it out from under the pointer.
+   */
+  reserveRow?: boolean,
   /** Called with the part a drag started from. */
   onPartDragStart?: (part: Part) => void,
 }
@@ -127,6 +134,10 @@ class PartsDrawer extends React.Component<IProps, IState> {
                 <PartTile key={part.component.uuid} part={part}
                           onDragStart={this.props.onPartDragStart}/>
               ))}
+              {/* One empty cell holds the row open. A tile rather than a measurement, so the space
+                  kept is whatever a tile turns out to occupy. */}
+              {this.props.reserveRow && this.props.parts.length === 0 &&
+                <div className="part part-placeholder" aria-hidden="true"/>}
             </div>
           </Collapse>
         </>

--- a/src/components/PartsPanel.test.tsx
+++ b/src/components/PartsPanel.test.tsx
@@ -85,19 +85,77 @@ describe('the recent section', () => {
     });
   }
 
-  test('is absent until a part has been reached for', () => {
+  test('is there before any part has been reached for', () => {
+    // It used to appear only once it had something in it, so the first drag of a session made it
+    // arrive and pushed every section below it down.
     render(<PartsPanel parts={parts()}/>);
 
-    expect(screen.queryByRole('button', {name: /recent/i})).toBeNull();
+    expect(section('Recent')).toBeInTheDocument();
   });
 
   test('holds the parts a drag started from', () => {
     render(<PartsPanel parts={parts()}/>);
     fireEvent.click(section('Gates'));
+    fireEvent.click(section('Recent'));
 
     drag('OR');
 
-    expect(section('Recent')).toBeInTheDocument();
+    expect(screen.getAllByText('OR')).toHaveLength(2);
+  });
+
+  test('holds a single row of parts', () => {
+    render(<PartsPanel parts={parts()}/>);
+    fireEvent.click(section('Gates'));
+    fireEvent.click(section('Recent'));
+
+    // Four different parts reached for, of which the section keeps the three most recent.
+    ['AND', 'OR', 'NAND'].forEach(drag);
+    fireEvent.click(section('Input'));
+    drag('Clock');
+
+    // Each surviving part appears twice, once in its own section and once here.
+    expect(screen.getAllByText('Clock')).toHaveLength(2);
+    expect(screen.getAllByText('NAND')).toHaveLength(2);
+    expect(screen.getAllByText('OR')).toHaveLength(2);
+    // The oldest has been pushed out, leaving it only in its own section.
+    expect(screen.getAllByText('AND')).toHaveLength(1);
+  });
+
+  test('keeps the height of a full row while it is empty', () => {
+    // The part arriving must not move what is below it: that is what pulls a tile out from under
+    // the pointer partway through the drag that put it there.
+    const {container} = render(<PartsPanel parts={parts()}/>);
+    fireEvent.click(section('Recent'));
+    expect(container.querySelectorAll('.parts-grid .part')).toHaveLength(1);
+    expect(container.querySelector('.part-placeholder')).toBeInTheDocument();
+
+    fireEvent.click(section('Gates'));
+    drag('OR');
+
+    // The placeholder gives way to the real tile, one cell for one cell.
+    expect(container.querySelector('.parts-grid .part-placeholder')).toBeNull();
+    expect(container.querySelectorAll('.parts-grid')[0].querySelectorAll('.part')).toHaveLength(1);
+  });
+
+  test('reserves nothing in the other sections', () => {
+    const {container} = render(<PartsPanel parts={parts()}/>);
+
+    fireEvent.click(section('Recent'));
+    fireEvent.click(section('Gates'));
+
+    // Recent is the first section, and the only one holding a cell open.
+    const grids = container.querySelectorAll('.parts-grid');
+    expect(grids[0].querySelector('.part-placeholder')).toBeInTheDocument();
+    expect(grids[1].querySelector('.part-placeholder')).toBeNull();
+  });
+
+  test('gives way to a filter that it does not match', () => {
+    render(<PartsPanel parts={parts()}/>);
+
+    fireEvent.change(filter(), {target: {value: 'zzz'}});
+
+    expect(screen.queryByRole('button', {name: /recent/i})).toBeNull();
+    expect(screen.getByText(/No parts match/)).toBeInTheDocument();
   });
 
   test('can be turned off from the options', () => {

--- a/src/components/PartsPanel.tsx
+++ b/src/components/PartsPanel.tsx
@@ -17,9 +17,11 @@ import "../css/PartsDrawer.css"
 /**
  * How many parts the Recent section holds.
  *
- * Three to a row, so this is two rows of them.
+ * Three to a row, so this is one row of them, and the section is the same height however many it
+ * is holding. A second row would grow the section as it filled, pushing everything below it down
+ * mid-drag — which is how the part being dragged ends up out from under the cursor.
  */
-const RECENT_LIMIT = 6;
+const RECENT_LIMIT = 3;
 
 const RECENT = "Recent";
 
@@ -62,14 +64,17 @@ class PartsPanel extends React.Component<IProps, IState> {
     const admits = (part: Part) => !query || part.label.toLowerCase().includes(query);
 
     const all: Array<[string, Part[]]> = [];
-    if (this.state.showRecent && this.state.recent.length > 0) {
+    if (this.state.showRecent) {
       all.push([RECENT, this.state.recent]);
     }
     all.push(...this.props.parts);
 
     return all
       .map(([label, parts]): [string, Part[]] => [label, parts.filter(admits)])
-      .filter(([, parts]) => parts.length > 0);
+      // Recent is a fixed part of the panel and stays whether or not it is holding anything, since
+      // a section that comes and goes moves everything under it. It gives way only to a filter,
+      // where a section with no matches is noise like any other.
+      .filter(([label, parts]) => parts.length > 0 || (!query && label === RECENT));
   }
 
   renderOptions() {
@@ -123,6 +128,7 @@ class PartsPanel extends React.Component<IProps, IState> {
             // Sections are opened by the filter rather than by the user, so a section closed
             // before the search would otherwise hide the very parts that matched it.
             <PartsDrawer key={label} label={label} parts={parts} forceOpen={filtering}
+                         reserveRow={label === RECENT}
                          onPartDragStart={part => this.recordUse(part)}/>
           ))}
           {sections.length === 0 &&

--- a/src/components/PinProperties.test.tsx
+++ b/src/components/PinProperties.test.tsx
@@ -155,3 +155,67 @@ describe('pin properties', () => {
     expect(screen.getByText(/must be unique/)).toBeInTheDocument();
   });
 });
+
+describe('committing a field with Enter', () => {
+  test('sets the net name, as the button beside it would', () => {
+    const {logicBoard, gate} = board();
+    const pin = gate(GateType.AND).outputPins[0];
+    showing(logicBoard, pin);
+
+    fireEvent.change(field('Net Name'), {target: {value: 'clk'}});
+    fireEvent.keyDown(field('Net Name'), {key: 'Enter'});
+
+    expect(pin.netName).toBe('clk');
+  });
+
+  test('sets the port name', () => {
+    const {logicBoard, gate} = board();
+    const pin = gate(GateType.AND).inputPins[0];
+    showing(logicBoard, pin);
+
+    fireEvent.click(screen.getByLabelText('Port'));
+    fireEvent.change(field('Port Name'), {target: {value: 'Reset'}});
+    fireEvent.keyDown(field('Port Name'), {key: 'Enter'});
+
+    expect(pin.isPort).toBe(true);
+    expect(pin.portName).toBe('Reset');
+  });
+
+  test('does nothing while the value is unchanged, matching the disabled button', () => {
+    const {logicBoard, gate} = board();
+    const pin = gate(GateType.AND).outputPins[0];
+    showing(logicBoard, pin);
+    let applied = 0;
+    const update = logicBoard.update;
+    logicBoard.update = () => {applied++; update()};
+
+    expect(setNet()).toBeDisabled();
+    fireEvent.keyDown(field('Net Name'), {key: 'Enter'});
+
+    expect(applied).toBe(0);
+  });
+
+  test('does nothing while the value is refused', () => {
+    // Two outputs describe a net that cannot exist, so neither the button nor Enter applies it.
+    const {logicBoard, gate} = board();
+    const [a, b] = [gate(GateType.AND).outputPins[0], gate(GateType.OR).outputPins[0]];
+    showing(logicBoard, a, b);
+
+    fireEvent.change(field('Net Name'), {target: {value: 'bus'}});
+    fireEvent.keyDown(field('Net Name'), {key: 'Enter'});
+
+    expect(a.netName).toBe('');
+    expect(b.netName).toBe('');
+  });
+
+  test('leaves other keys to the field', () => {
+    const {logicBoard, gate} = board();
+    const pin = gate(GateType.AND).outputPins[0];
+    showing(logicBoard, pin);
+
+    fireEvent.change(field('Net Name'), {target: {value: 'clk'}});
+    fireEvent.keyDown(field('Net Name'), {key: 'a'});
+
+    expect(pin.netName).toBe('');
+  });
+});

--- a/src/components/PinProperties.tsx
+++ b/src/components/PinProperties.tsx
@@ -10,6 +10,7 @@ import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import Check from "@mui/icons-material/Check";
+import InfoOutlined from "@mui/icons-material/InfoOutlined";
 
 import {LogicBoard} from "../logic/LogicBoard";
 import {LogicPin, PinType} from "../logic/LogicPin";
@@ -17,6 +18,30 @@ import {checkNetName, checkPortName, isConnectableGroup, setNetName, setPort} fr
 
 /** Shown in place of a value when the selection does not agree on one. */
 const MIXED = "-";
+
+/** The net name field, named so that the board can put the caret in it. */
+const NET_NAME_FIELD = "pin-net-name";
+
+/** How pins are joined, which nothing else on screen says. */
+const CONNECT_HINT = "Select an output and the inputs it should drive, then press Space to wire "
+    + "them together and name the net.";
+
+/**
+ * Commits a field on Enter, where its own button would have.
+ *
+ * Enter in a lone text field usually means "that is my answer", and here the answer is only taken
+ * once the button beside it is pressed. Reading the same disabled state the button does keeps the
+ * two from disagreeing about whether the value can be applied at all.
+ */
+function applyOnEnter(disabled: boolean, apply: () => void) {
+  return (e: React.KeyboardEvent) => {
+    if (e.key !== "Enter" || disabled) {
+      return;
+    }
+    e.preventDefault();
+    apply();
+  };
+}
 
 interface IProps {
   board: LogicBoard;
@@ -29,6 +54,32 @@ interface IState {
   netName: string;
   portName: string;
   isPort: boolean;
+  /**
+   * What the pins said when the fields were last filled from them.
+   *
+   * The fields hold a draft rather than the pins themselves, since neither is applied until it is
+   * committed. Keeping what the draft was taken from is what tells a value the user has typed and
+   * not yet applied apart from one that has since changed underneath them.
+   */
+  taken: Values;
+}
+
+/** The three things the fields describe, as they stand on the pins. */
+interface Values {
+  netName: string;
+  portName: string;
+  isPort: boolean;
+}
+
+/** What the fields would hold if they were filled from the pins now. */
+function valuesOf(pins: LogicPin[]): Values {
+  const [pin] = pins;
+
+  return {
+    netName: shared(pins, p => p.netName) ?? "",
+    portName: pin?.portName ?? "",
+    isPort: pin?.isPort ?? false,
+  };
 }
 
 /** The value every pin agrees on, or undefined where they differ. */
@@ -61,12 +112,30 @@ class PinProperties extends React.Component<IProps, IState> {
   constructor(props: Readonly<IProps>) {
     super(props);
 
-    const [pin] = props.pins;
-    this.state = {
-      netName: shared(props.pins, p => p.netName) ?? "",
-      portName: pin?.portName ?? "",
-      isPort: pin?.isPort ?? false,
-    };
+    const taken = valuesOf(props.pins);
+    this.state = {...taken, taken};
+  }
+
+  /**
+   * Fills the fields again when the pins change underneath them.
+   *
+   * Wiring a pin up moves it onto the net its driver is on, which the panel has to show: it was
+   * reading the pins once, when it was built, so a name changed by anything but the panel itself
+   * sat there stale until the panel was rebuilt.
+   *
+   * A draft the user is part-way through typing survives, since only a value that has moved on the
+   * pins replaces it.
+   */
+  static getDerivedStateFromProps(props: IProps, state: IState): Partial<IState> | null {
+    const now = valuesOf(props.pins);
+    const {taken} = state;
+
+    if (now.netName === taken.netName && now.portName === taken.portName
+        && now.isPort === taken.isPort) {
+      return null;
+    }
+
+    return {...now, taken: now};
   }
 
   /** A net takes one output at most, so a selection with two describes no possible net. */
@@ -115,11 +184,12 @@ class PinProperties extends React.Component<IProps, IState> {
       : {error: "A net can only be driven by one output."};
     const unchanged = this.state.netName.trim() === (shared(this.props.pins, p => p.netName) ?? "");
     const warned = Boolean(check.warning) && !check.error;
+    const cannotApply = !editable || Boolean(check.error) || unchanged;
 
     return (
       <>
         <TextField
-          id="pin-net-name"
+          id={NET_NAME_FIELD}
           label="Net Name"
           size="small"
           variant="standard"
@@ -129,6 +199,7 @@ class PinProperties extends React.Component<IProps, IState> {
           value={this.state.netName}
           placeholder={shared(this.props.pins, p => p.netName) === undefined ? MIXED : ""}
           onChange={e => this.setState({netName: e.target.value})}
+          onKeyDown={applyOnEnter(cannotApply, () => this.applyNetName())}
           // A field has an error state but no warning one. MUI's way of colouring a field from the
           // rest of the palette is to name the colour and hold the field in its focused look, since
           // that look is the one the colour shows through.
@@ -136,8 +207,7 @@ class PinProperties extends React.Component<IProps, IState> {
           focused={warned || undefined}
           InputProps={{
             endAdornment: this.renderApply(
-              "Set net name", !editable || Boolean(check.error) || unchanged,
-              () => this.applyNetName()),
+              "Set net name", cannotApply, () => this.applyNetName()),
           }}/>
         {/* A clash with another output is worth saying but not worth blocking, and the colour alone
             does not say what is wrong with the value. */}
@@ -156,6 +226,7 @@ class PinProperties extends React.Component<IProps, IState> {
       : undefined;
     const unchanged = this.state.isPort === pin.isPort
       && this.state.portName.trim() === pin.portName;
+    const cannotApply = Boolean(problem) || unchanged;
 
     return (
       <>
@@ -175,9 +246,10 @@ class PinProperties extends React.Component<IProps, IState> {
             error={Boolean(problem)}
             value={this.state.portName}
             onChange={e => this.setState({portName: e.target.value})}
+            onKeyDown={applyOnEnter(cannotApply, () => this.applyPort())}
             InputProps={{
               endAdornment: this.renderApply(
-                "Set port name", Boolean(problem) || unchanged, () => this.applyPort()),
+                "Set port name", cannotApply, () => this.applyPort()),
             }}/>
         </Stack>
         {/* One line, saying whatever stands between this pin and being a port: what is missing, what
@@ -190,6 +262,21 @@ class PinProperties extends React.Component<IProps, IState> {
     );
   }
 
+  /**
+   * Says how pins are wired without a wire.
+   *
+   * The panel can show a net once it has a name, but nothing on screen says how a set of pins is
+   * turned into one in the first place, and a key nobody presses teaches nobody anything.
+   */
+  renderConnectHint() {
+    return (
+      <Tooltip title={CONNECT_HINT}>
+        <InfoOutlined aria-label={CONNECT_HINT} tabIndex={0}
+                      sx={{fontSize: 16, color: "text.secondary"}}/>
+      </Tooltip>
+    );
+  }
+
   render() {
     const {pins} = this.props;
     const type = shared(pins, p => p.pinType);
@@ -198,7 +285,10 @@ class PinProperties extends React.Component<IProps, IState> {
     return (
       <Box className="properties-body">
         <Row label="Type">
-          <Typography variant="body2" className="properties-value">Pin</Typography>
+          <Stack direction="row" alignItems="center" spacing={0.75}>
+            <Typography variant="body2" className="properties-value">Pin</Typography>
+            {this.renderConnectHint()}
+          </Stack>
         </Row>
         {pins.length > 1 &&
           <Typography variant="caption" color="text.secondary">
@@ -223,4 +313,4 @@ class PinProperties extends React.Component<IProps, IState> {
   }
 }
 
-export {PinProperties};
+export {NET_NAME_FIELD, PinProperties};

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -16,6 +16,8 @@ import Tooltip from "@mui/material/Tooltip"
 import Save from "@mui/icons-material/Save";
 import GridOn from "@mui/icons-material/GridOn";
 import GridOff from "@mui/icons-material/GridOff";
+import Link from "@mui/icons-material/Link";
+import LinkOff from "@mui/icons-material/LinkOff";
 import Delete from "@mui/icons-material/Delete";
 import ContentCut from "@mui/icons-material/ContentCut";
 import ContentCopy from "@mui/icons-material/ContentCopy";
@@ -105,6 +107,29 @@ class Toolbar extends React.Component<IProps, IState> {
     );
   }
 
+  /**
+   * Whether clicking a pin the selection can reach wires it up.
+   *
+   * A toggle rather than something that just happens, so that there is somewhere for the feature to
+   * be found: the tooltip is where a user who has never made a connection this way is told it can
+   * be done at all.
+   */
+  connectOnClickButton() {
+    const on = this.props.board.connectOnClick;
+    const label = on
+      ? "Connect on click: on — click a compatible pin to wire it to the selection"
+      : "Connect on click: off — select pins, then click a compatible pin to wire them";
+
+    return (
+      <Tooltip title={label}>
+        <IconButton className={on ? "pressed" : ""} onClick={this.onToggleConnectOnClick.bind(this)}
+                    aria-label={label} aria-pressed={on}>
+          {on ? <Link fontSize="small"/> : <LinkOff fontSize="small"/>}
+        </IconButton>
+      </Tooltip>
+    );
+  }
+
   render() {
     const running = this.props.board.simulationRunning;
     const stopped = !running && this.props.board.simulationStopped;
@@ -154,6 +179,7 @@ class Toolbar extends React.Component<IProps, IState> {
               </IconButton>
             </Tooltip>
             {this.snapToGridButton()}
+            {this.connectOnClickButton()}
           </Box>
           <Box>
             {this.action("Cut", "Cut (Ctrl+X)", <ContentCut fontSize="small"/>, this.props.onCut)}
@@ -189,6 +215,13 @@ class Toolbar extends React.Component<IProps, IState> {
 
   onStep() {
     this.props.board.advanceSimulation()
+  }
+
+  onToggleConnectOnClick() {
+    this.props.board.connectOnClick = !this.props.board.connectOnClick;
+    writeSettings({connectOnClick: this.props.board.connectOnClick});
+    // Nothing on the board changes, so only this button has anything to redraw.
+    this.setState({});
   }
 
   onCycleSnapMode() {

--- a/src/css/PartsDrawer.css
+++ b/src/css/PartsDrawer.css
@@ -122,6 +122,15 @@
     cursor: grabbing;
 }
 
+/* Occupies its cell without drawing or catching anything, so the row it holds open is empty.
+   Carries the border a real tile is given so that it stands exactly as tall as the tile that will
+   replace it, which is the whole point of it being here. */
+.part-placeholder {
+    visibility: hidden;
+    pointer-events: none;
+    border: 1px solid transparent;
+}
+
 .part-image {
     display: flex;
     align-items: center;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -16,6 +16,21 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow: hidden;
+
+  /* The interface is made of controls rather than of prose: its labels, headings and the writing on
+     the board are there to be read, and dragging across them should move what is under the pointer
+     instead of highlighting what is written on it. On the body rather than the app's own root, so
+     that it reaches the menus and dialogs the framework hangs off the end of the document. */
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* What the user typed is theirs to select, copy and correct. */
+input,
+textarea,
+[contenteditable="true"] {
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 code {

--- a/src/logic/LogicBoard.tsx
+++ b/src/logic/LogicBoard.tsx
@@ -16,6 +16,7 @@ import { smallestEnclosingCircle } from "../util/enclosingCircle";
 import { normalizeAngleOffset } from "../util/angle";
 import { WireStyle } from "../util/wireStyle";
 import { snapSizeFor, SnapMode } from "../util/grid";
+import { leaveNets } from "./nets";
 import { readSettings } from "../storage/settings";
 import { mergeProperties, MergedProperty } from "../util/mergeProperties";
 
@@ -101,6 +102,14 @@ class LogicBoard {
    * than anything about the circuit, so it is not written to a board's file.
    */
   snapMode: SnapMode = readSettings().snapMode;
+
+  /**
+   * Whether clicking a pin the selection can reach wires it up instead of selecting it.
+   *
+   * Off unless asked for. It changes what clicking a pin does, and a mode nobody turned on is one
+   * they have no reason to suspect when a click does something they did not expect.
+   */
+  connectOnClick: boolean = readSettings().connectOnClick;
 
   /** How far apart the positions a component may be placed on are, or zero while snapping is off. */
   get snapSize(): number {
@@ -376,6 +385,9 @@ class LogicBoard {
     for (const pin of pins) {
       pin.disconnect();
     }
+    // Unwiring a pin takes it off its net, since being on one is what says it is wired to the rest.
+    // The pins at the far end are left as they are: they were not what was deleted.
+    leaveNets(pins);
 
     this.clearSelection();
     this.update();

--- a/src/logic/LogicPin.tsx
+++ b/src/logic/LogicPin.tsx
@@ -347,8 +347,28 @@ class LogicPin {
     return this.transform(anchor).getDistance(point)
   }
 
+  /**
+   * Whether a board point is close enough to drop a connection on this pin.
+   *
+   * The circle at the end of the pin adds to what the pin already covers rather than standing in
+   * for it: it is there to make the point a wire attaches to easier to hit than the width of the
+   * pin allows, so aiming at the pin itself has to work too.
+   */
   isOver(point: paper.Point): boolean {
-    return this.distanceTo(point) < LogicPin.ANCHOR_RADIUS
+    return this.distanceTo(point) < LogicPin.ANCHOR_RADIUS || this.covers(point);
+  }
+
+  /** Whether a board point falls on the pin as drawn. */
+  covers(point: paper.Point): boolean {
+    if (!this.geometry) {
+      return false;
+    }
+
+    // The pin's geometry is held in its component's frame, which is where the point has to be
+    // brought to be compared against it.
+    const local = this.parent.geometry.matrix.inverted().transform(point);
+
+    return this.geometry.contains(local);
   }
 
   /**

--- a/src/logic/nets.ts
+++ b/src/logic/nets.ts
@@ -107,27 +107,95 @@ function checkNetName(board: LogicBoard, pins: LogicPin[], name: string): NetNam
 }
 
 /**
- * Wires a net up: its one output driving each of its inputs.
+ * Wires a set of pins up: the one output among them driving each of the inputs.
  *
- * The width check refuses a net that would mix widths, so the guard below should never fire; it is
- * there because connecting pins that cannot be connected would otherwise fail silently.
+ * Says how many wires it made, and draws nothing itself, so a caller can tell whether the board is
+ * worth redrawing. Pins it cannot join are passed over: a set with no output has nothing to drive
+ * it, and the width check refuses a net that would mix widths, so the guard below should never
+ * fire for a named net — it is there because connecting pins that cannot be connected would
+ * otherwise fail silently.
  */
-function rewireNet(board: LogicBoard, name: string) {
-  const members = pinsOnNet(board, name);
-  const driver = members.find(pin => pin.pinType === PinType.OUTPUT);
-  if (!driver) {
-    return;
+function connectPins(board: LogicBoard, pins: LogicPin[]): number {
+  const driver = pins.find(pin => pin.pinType === PinType.OUTPUT);
+  if (!driver || !isConnectableGroup(pins)) {
+    return 0;
   }
 
-  for (const pin of members) {
+  let made = 0;
+  for (const pin of pins) {
     if (pin === driver || pin.pinType !== PinType.INPUT || !pin.canConnect(driver)) {
       continue;
     }
     const connection = pin.connectTo(driver);
     if (connection) {
       board.addConnection(connection);
+      adoptNet(driver, pin);
+      made++;
     }
   }
+
+  return made;
+}
+
+/**
+ * Takes pins off their nets, for wires the user has cut.
+ *
+ * Sharing a net name is the same thing as being connected, so a pin unwired on purpose has to stop
+ * claiming the name as well. Only the pins the user picked out: the ones at the far end were not
+ * what was deleted, they keep both their name and each other, and a net that has lost its driver
+ * is still a net to be on.
+ *
+ * Only for wires removed on purpose. Connecting an input disconnects it first, since an input takes
+ * one source at a time, so clearing names on every disconnection would wipe the name a pin was just
+ * given as it was being wired up under it.
+ */
+function leaveNets(pins: Iterable<LogicPin>) {
+  for (const pin of pins) {
+    pin.netName = "";
+  }
+}
+
+/**
+ * Puts the far end of a new wire onto the net its driver is on.
+ *
+ * Two pins that are wired together are on one net and so answer to one name, and an output is its
+ * net: the input takes whatever the output is called, or comes off the net it was on when the
+ * output is on none.
+ */
+function adoptNet(source: LogicPin, sink: LogicPin) {
+  sink.netName = source.netName;
+}
+
+/**
+ * Whether wiring this pin to the given ones would actually join it to them.
+ *
+ * Asked of a pin the user is pointing at, so it has to be about that pin rather than about the set
+ * as a whole: a target the set cannot reach must read as unreachable even where the set holds
+ * pins that could be joined to each other.
+ */
+function wouldConnect(pins: LogicPin[], target: LogicPin): boolean {
+  if (pins.length === 0 || pins.includes(target)) {
+    return false;
+  }
+
+  const all = [...pins, target];
+  if (!isConnectableGroup(all)) {
+    return false;
+  }
+
+  const driver = all.find(pin => pin.pinType === PinType.OUTPUT);
+  if (!driver) {
+    return false;
+  }
+
+  return target === driver
+    ? pins.some(pin => pin.pinType === PinType.INPUT && pin.canConnect(driver))
+    : target.pinType === PinType.INPUT && target.canConnect(driver);
+}
+
+/** Wires a net up: its one output driving each of its inputs. */
+function rewireNet(board: LogicBoard, name: string) {
+  connectPins(board, pinsOnNet(board, name));
 }
 
 /**
@@ -197,6 +265,7 @@ function setPort(board: LogicBoard, pin: LogicPin, isPort: boolean, name: string
 }
 
 export {
-  checkNetName, checkPortName, connectedGroup, isConnectableGroup, pinsOnNet, setNetName, setPort,
+  adoptNet, checkNetName, checkPortName, connectedGroup, connectPins, isConnectableGroup,
+  leaveNets, pinsOnNet, setNetName, setPort, wouldConnect,
 };
 export type {NetNameCheck};

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -25,6 +25,8 @@ interface Settings {
   wireStyle: WireStyle;
   /** Whether a component being placed lands on the grid, and how coarse that grid is. */
   snapMode: SnapMode;
+  /** Whether clicking a pin the selection can reach wires it up instead of selecting it. */
+  connectOnClick: boolean;
   /** Most recently opened first. */
   recentProjects: RecentProject[];
 }
@@ -32,6 +34,7 @@ interface Settings {
 const DEFAULTS: Settings = {
   wireStyle: DEFAULT_WIRE_STYLE,
   snapMode: "off",
+  connectOnClick: false,
   recentProjects: [],
 };
 
@@ -72,6 +75,9 @@ function readSettings(): Settings {
   return {
     wireStyle: isWireStyle(settings.wireStyle) ? settings.wireStyle : DEFAULTS.wireStyle,
     snapMode: isSnapMode(settings.snapMode) ? settings.snapMode : DEFAULTS.snapMode,
+    connectOnClick: typeof settings.connectOnClick === "boolean"
+        ? settings.connectOnClick
+        : DEFAULTS.connectOnClick,
     recentProjects: Array.isArray(settings.recentProjects)
         ? settings.recentProjects.filter(isRecentProject).slice(0, RECENT_PROJECT_LIMIT)
         : [],

--- a/src/util/MouseManager.ts
+++ b/src/util/MouseManager.ts
@@ -8,6 +8,7 @@ import {MouseEventMapping} from "./MouseEventMapping";
 import { MouseEventHandler, MouseEventName } from "./Types";
 import { SelectionMode, selectionModeFor } from "./selectionMode";
 import { snapTo } from "./grid";
+import { adoptNet, connectPins, wouldConnect } from "../logic/nets";
 
 
 enum MouseAction {
@@ -261,6 +262,20 @@ class MouseManager {
     this.mouseButton = e.button;
 
     const mode = selectionModeFor(e);
+
+    // With connect-on-click on, a plain click on a pin the selection can reach joins them instead
+    // of selecting it. The selection stays, so an output can be clicked out to one input after
+    // another without being picked up again each time.
+    if (board.connectOnClick && mode === SelectionMode.REPLACE
+        && wouldConnect([...board.selectedPins], target)) {
+      if (connectPins(board, [...board.selectedPins, target]) > 0) {
+        board.update();
+      }
+      board.updateProperties();
+
+      return;
+    }
+
     const next = MouseManager.clicked(mode, board.selectedPins, target,
         board.selectedComponents.size > 0);
     if (next) {
@@ -288,6 +303,7 @@ class MouseManager {
     const connection = a.connectTo(b);
     if (connection) {
       board.addConnection(connection);
+      adoptNet(connection.source, connection.sink);
       board.update();
     }
   }

--- a/src/util/connectionDrop.test.ts
+++ b/src/util/connectionDrop.test.ts
@@ -101,19 +101,66 @@ describe('dropping a connection', () => {
     expect(source.isConnectedTo(aimedAt)).toBe(true);
   });
 
-  test('accepts a drop exactly as far out as the circle it draws', () => {
-    // The catch area and the drawn circle are the same affordance. While the hit test was three
-    // times the radius of the circle, a drop could register on a pin the user never touched.
+  test('reaches exactly as far past the pin as the circle it draws', () => {
+    // Away from the pin the circle is the whole of the catch area, and it is the size it looks.
+    // While the hit test was three times the radius drawn, a drop could register on a pin the user
+    // never touched.
     const board = new LogicBoard();
     const display = new SegmentDisplay({scope: board.scope, subtype: 1, isMerged: false});
     place(board, display);
     const target = display.inputPins[0];
     const at = anchorOf(target);
 
-    const inset = (offset: number) => new board.scope.Point(at.x, at.y - offset);
+    // Out along the pin, away from the component, where nothing but the circle covers.
+    const beyond = (offset: number) => new board.scope.Point(at.x - offset, at.y);
 
-    expect(target.isOver(inset(LogicPin.ANCHOR_RADIUS - 0.5))).toBe(true);
-    expect(target.isOver(inset(LogicPin.ANCHOR_RADIUS + 0.5))).toBe(false);
+    expect(target.isOver(beyond(LogicPin.ANCHOR_RADIUS - 0.5))).toBe(true);
+    expect(target.isOver(beyond(LogicPin.ANCHOR_RADIUS + 0.5))).toBe(false);
+  });
+
+  test('accepts a drop on the pin itself, well clear of the circle', () => {
+    // The circle extends the pin's reach rather than replacing it, so the length of the pin between
+    // the circle and the component body takes a drop too.
+    const board = new LogicBoard();
+    const display = new SegmentDisplay({scope: board.scope, subtype: 1, isMerged: false});
+    place(board, display);
+    const target = display.inputPins[0];
+    const at = anchorOf(target);
+
+    // Back along the pin towards the body, past anything the circle covers.
+    const along = new board.scope.Point(at.x + LogicPin.ANCHOR_RADIUS * 2, at.y);
+
+    expect(target.distanceTo(along)).toBeGreaterThan(LogicPin.ANCHOR_RADIUS);
+    expect(target.covers(along)).toBe(true);
+    expect(target.isOver(along)).toBe(true);
+  });
+
+  test('connects a wire dropped on the pin rather than on its circle', () => {
+    const board = new LogicBoard();
+    const display = new SegmentDisplay({scope: board.scope, subtype: 1, isMerged: false});
+    place(board, display);
+    const source = driver(board);
+    const target = display.inputPins[0];
+    const at = anchorOf(target);
+
+    dropAt(board, source, {x: at.x + LogicPin.ANCHOR_RADIUS * 2, y: at.y});
+
+    expect(source.isConnectedTo(target)).toBe(true);
+  });
+
+  test('still refuses a drop beside the pin, off both the pin and its circle', () => {
+    const board = new LogicBoard();
+    const display = new SegmentDisplay({scope: board.scope, subtype: 1, isMerged: false});
+    place(board, display);
+    const target = display.inputPins[0];
+    const at = anchorOf(target);
+
+    // Alongside the pin rather than on it, further out than the circle reaches.
+    const beside = new board.scope.Point(at.x + LogicPin.ANCHOR_RADIUS * 2,
+                                         at.y + LogicPin.ANCHOR_RADIUS * 3);
+
+    expect(target.covers(beside)).toBe(false);
+    expect(target.isOver(beside)).toBe(false);
   });
 
   test('connects nothing when the drop is not near any pin', () => {


### PR DESCRIPTION
Pin Connection:
- Select then space
- Select then click

Bug fixes:
- Pin bodies now accept drops to connect
- "Recents" section now always visible with fixed content size
- Net names now properly cleared when selected pins are deleted
- Net names now properly assigned when a new connection is created.
- Most text content no long selectable