### PR TITLE
Port Name Uniqueness

### DIFF
--- a/src/components/PinProperties.test.tsx
+++ b/src/components/PinProperties.test.tsx
@@ -113,9 +113,9 @@ describe('pin properties', () => {
     expect(screen.queryByLabelText('Port')).toBeNull();
   });
 
-  test('will not take a port name another port already has', () => {
+  test('will not take a port name an output already drives', () => {
     const {logicBoard, gate} = board();
-    const taken = gate(GateType.AND).inputPins[0];
+    const taken = gate(GateType.AND).outputPins[0];
     taken.isPort = true;
     taken.portName = 'A';
     const pin = gate(GateType.OR).inputPins[0];
@@ -124,9 +124,25 @@ describe('pin properties', () => {
     fireEvent.click(screen.getByLabelText('Port'));
     fireEvent.change(field('Port Name'), {target: {value: 'A'}});
 
-    expect(screen.getByText(/already the port/)).toBeInTheDocument();
+    expect(screen.getByText(/already an output port/)).toBeInTheDocument();
     expect(field('Port Name')).toHaveAttribute('aria-invalid', 'true');
     expect(setPortName()).toBeDisabled();
+  });
+
+  test('takes a port name another input already has, since they share the exposed pin', () => {
+    const {logicBoard, gate} = board();
+    const other = gate(GateType.AND).inputPins[0];
+    other.isPort = true;
+    other.portName = 'A';
+    const pin = gate(GateType.OR).inputPins[0];
+    showing(logicBoard, pin);
+
+    fireEvent.click(screen.getByLabelText('Port'));
+    fireEvent.change(field('Port Name'), {target: {value: 'A'}});
+    fireEvent.click(setPortName());
+
+    expect(pin.isPort).toBe(true);
+    expect(pin.portName).toBe('A');
   });
 
   test('accepts a free port name', () => {
@@ -142,7 +158,7 @@ describe('pin properties', () => {
     expect(pin.portName).toBe('Reset');
   });
 
-  test('asks for a name before it asks for a unique one', () => {
+  test('asks for a name before it says how names may be shared', () => {
     const {logicBoard, gate} = board();
     showing(logicBoard, gate(GateType.AND).inputPins[0]);
 
@@ -152,7 +168,8 @@ describe('pin properties', () => {
     fireEvent.change(field('Port Name'), {target: {value: 'Reset'}});
 
     // Nothing wrong with it, so the rule it has to keep meeting is what is left to say.
-    expect(screen.getByText(/must be unique/)).toBeInTheDocument();
+    expect(screen.queryByText(/needs a name/)).toBeNull();
+    expect(screen.getByText(/share/i)).toBeInTheDocument();
   });
 });
 

--- a/src/components/PinProperties.tsx
+++ b/src/components/PinProperties.tsx
@@ -211,7 +211,7 @@ class PinProperties extends React.Component<IProps, IState> {
         </Stack>
         {this.state.isPort &&
           <Typography variant="caption" color={problem ? "error" : "text.secondary"}>
-            {problem ?? "Port names must be unique across the board."}
+            {problem ?? "Inputs may share a port name. An output port takes its name alone."}
           </Typography>}
       </>
     );

--- a/src/logic/nets.test.ts
+++ b/src/logic/nets.test.ts
@@ -283,17 +283,49 @@ describe('exposing a pin as a port', () => {
     expect(pin.portName).toBe('A');
   });
 
-  test('refuses a name another port already has', () => {
+  test('lets inputs share a name, since one exposed pin drives them all', () => {
     const {logicBoard, gate} = board();
     const first = gate(GateType.AND).inputPins[0];
     const second = gate(GateType.OR).inputPins[0];
     setPort(logicBoard, first, true, 'A');
 
-    expect(checkPortName(logicBoard, second, 'A')).toContain('already the port');
+    expect(checkPortName(logicBoard, second, 'A')).toBeUndefined();
+
+    setPort(logicBoard, second, true, 'A');
+
+    expect(second.isPort).toBe(true);
+    expect(second.portName).toBe('A');
+  });
+
+  test('refuses a second output on one name, which has nothing to drive it', () => {
+    const {logicBoard, gate} = board();
+    const first = gate(GateType.AND).outputPins[0];
+    const second = gate(GateType.OR).outputPins[0];
+    setPort(logicBoard, first, true, 'A');
+
+    expect(checkPortName(logicBoard, second, 'A')).toContain('already an output port');
 
     setPort(logicBoard, second, true, 'A');
 
     expect(second.isPort).toBe(false);
+  });
+
+  test('refuses an input the name an output drives, which would make the pin both', () => {
+    const {logicBoard, gate} = board();
+    const driver = gate(GateType.AND).outputPins[0];
+    const listener = gate(GateType.OR).inputPins[0];
+    setPort(logicBoard, driver, true, 'A');
+
+    expect(checkPortName(logicBoard, listener, 'A')).toContain('already an output port');
+  });
+
+  test('refuses an output the name inputs are already listening on', () => {
+    const {logicBoard, gate} = board();
+    const listener = gate(GateType.AND).inputPins[0];
+    const driver = gate(GateType.OR).outputPins[0];
+    setPort(logicBoard, listener, true, 'A');
+
+    expect(checkPortName(logicBoard, driver, 'A')).toContain('already an input port');
   });
 
   test('frees the name once the pin stops being a port', () => {

--- a/src/logic/nets.ts
+++ b/src/logic/nets.ts
@@ -194,15 +194,29 @@ function setNetName(board: LogicBoard, pins: LogicPin[], name: string) {
   board.updateProperties();
 }
 
+/**
+ * One port name is one pin on the outside of the board, so the net rule applies across it: at most
+ * one output drives it. Inputs share a name freely, and the exposed pin then drives all of them.
+ *
+ * An output meeting an input under one name would need that pin to drive and be driven at once,
+ * which is the bidirectional case the simulation does not have.
+ */
 function checkPortName(board: LogicBoard, pin: LogicPin, name: string): string | undefined {
-  if (!name.trim()) {
+  const wanted = name.trim();
+  if (!wanted) {
     return "A port needs a name.";
   }
 
-  const taken = [...board.pins.values()]
-    .some(other => other !== pin && other.isPort && other.portName === name.trim());
+  const sharing = [...board.pins.values()]
+    .filter(other => other !== pin && other.isPort && other.portName === wanted);
 
-  return taken ? `Another pin is already the port "${name.trim()}".` : undefined;
+  if (sharing.some(other => other.pinType === PinType.OUTPUT)) {
+    return `"${wanted}" is already an output port.`;
+  }
+
+  return pin.pinType === PinType.OUTPUT && sharing.length > 0
+    ? `"${wanted}" is already an input port.`
+    : undefined;
 }
 
 function setPort(board: LogicBoard, pin: LogicPin, isPort: boolean, name: string) {


### PR DESCRIPTION
Port name uniqueness only required for outputs to align with net name requirements.